### PR TITLE
Add execution_slot_var option to Clojure test runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Concurrency-slot support for the test runner.** New
+  `[clojure-test-runner].execution_slot_var` option (mirroring pytest's
+  `[pytest].execution_slot_var`). When set, Pants assigns each concurrent
+  Clojure test process a unique integer slot id (0..N-1, where N is the local
+  process parallelism) and exposes it to the test JVM via the named env var.
+  Tests can use this id to partition shared resources across parallel
+  workers — e.g. compute a non-overlapping TCP port window per worker
+  (`start = base + slot * size`), pick a private temp directory, or
+  namespace a database under test.
+
+  Implementation note: `JvmProcess` does not currently forward
+  `execution_slot_variable` to the underlying `Process`, so the test rule
+  does the forwarding itself with `dataclasses.replace` after
+  `jvm_process(...)`.
+
 ## [0.1.0] - 2026-01-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -173,6 +173,41 @@ clojure_tests(
 )
 ```
 
+#### Concurrency slots for parallel tests
+
+When tests grab shared host resources (TCP ports, on-disk paths, database
+names, …) parallel runs collide. Mirroring pytest's
+`[pytest].execution_slot_var`, the Clojure test runner can hand each
+concurrent test process a unique integer slot id:
+
+```toml
+# pants.toml
+[clojure-test-runner]
+execution_slot_var = "PANTS_EXECUTION_SLOT"
+```
+
+Each running test JVM then sees a `PANTS_EXECUTION_SLOT` env var with an
+integer in `[0, parallelism)`. Use it to derive non-overlapping resource
+ranges, e.g. a private port window per worker:
+
+```clojure
+(let [slot  (Long/parseLong
+              (or (System/getenv "PANTS_EXECUTION_SLOT")
+                  (throw (ex-info "PANTS_EXECUTION_SLOT not set — configure [clojure-test-runner].execution_slot_var" {}))))
+      base  30000
+      size  200
+      port-start (+ base (* slot size))
+      port-end   (+ port-start size -1)]
+  ;; bind your test fixtures to ports in [port-start, port-end]
+  ...)
+```
+
+Failing loudly when the env var is unset is intentional — silently
+defaulting to slot 0 would collapse every worker onto the same resource
+window, defeating the point of the feature.
+
+Slot count is governed by `[GLOBAL].process_execution_local_parallelism`.
+
 ### `clojure_deploy_jar`
 
 An executable uberjar with AOT compilation.

--- a/pants-plugins/pants_backend_clojure/goals/test.py
+++ b/pants-plugins/pants_backend_clojure/goals/test.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from pants.core.goals.test import (
@@ -21,6 +21,7 @@ from pants.engine.internals.graph import transitive_targets
 from pants.engine.intrinsics import execute_process_with_retry, get_digest_contents, merge_digests
 from pants.engine.process import (
     InteractiveProcess,
+    Process,
     ProcessCacheScope,
     ProcessWithRetries,
 )
@@ -29,10 +30,10 @@ from pants.engine.target import SourcesField, TransitiveTargetsRequest
 from pants.jvm.classpath import classpath as classpath_get
 from pants.jvm.jdk_rules import JdkRequest, JvmProcess, jvm_process, prepare_jdk_environment
 from pants.jvm.subsystems import JvmSubsystem
-from pants.option.option_types import ArgsListOption, SkipOption
+from pants.option.option_types import ArgsListOption, SkipOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.logging import LogLevel
-
+from pants.util.strutil import softwrap
 from pants_backend_clojure.target_types import (
     ClojureSourceField,
     ClojureTestFieldSet,
@@ -61,9 +62,37 @@ class ClojureTestSubsystem(Subsystem):
     skip = SkipOption("test")
     args = ArgsListOption(example="-Djdk.attach.allowAttachSelf")
 
+    execution_slot_var = StrOption(
+        default=None,
+        advanced=True,
+        help=softwrap(
+            """
+            If set, each test process is given an integer "slot" id — unique
+            among concurrently-running test processes — and that id is exposed
+            to the test JVM as an environment variable with this name.
+
+            Use this to partition shared resources across parallel test
+            workers — e.g. give each worker a non-overlapping TCP port window
+            (`start = base + slot * size`), a private temp directory, or a
+            distinct database name — so parallel runs don't collide.
+
+            Slot ids range from 0 to N-1, where N is Pants' local process
+            parallelism (`[GLOBAL].process_execution_local_parallelism`).
+            """
+        ),
+    )
+
 
 # ClojureTestFieldSet is now defined in target_types.py to avoid circular dependencies
 # and allow both the test runner and compiler to use the same field set definition
+
+
+def _forward_slot_var(process: Process, slot_var: str | None) -> Process:
+    # TODO: remove once JvmProcess forwards execution_slot_variable to the
+    # underlying Process (upstream pantsbuild/pants).
+    if not slot_var:
+        return process
+    return replace(process, execution_slot_variable=slot_var)
 
 
 class ClojureTestRequest(TestRequest):
@@ -207,6 +236,7 @@ async def setup_clojure_test_for_target(
 @rule(desc="Run Clojure tests", level=LogLevel.DEBUG)
 async def run_clojure_test(
     test_subsystem: TestSubsystem,
+    clojure_test: ClojureTestSubsystem,
     batch: ClojureTestRequest.Batch[ClojureTestFieldSet, Any],
 ) -> TestResult:
     field_set = batch.single_element
@@ -217,6 +247,7 @@ async def run_clojure_test(
     # Convert JvmProcess to Process
     jvm_proc = test_setup.process
     process = await jvm_process(**implicitly({jvm_proc: JvmProcess}))
+    process = _forward_slot_var(process, clojure_test.execution_slot_var)
 
     # Execute with retry support
     process_results = await execute_process_with_retry(ProcessWithRetries(process, test_subsystem.attempts_default), **implicitly())
@@ -230,11 +261,13 @@ async def run_clojure_test(
 
 @rule(level=LogLevel.DEBUG)
 async def setup_clojure_test_debug_request(
+    clojure_test: ClojureTestSubsystem,
     batch: ClojureTestRequest.Batch[ClojureTestFieldSet, Any],
 ) -> TestDebugRequest:
     setup = await setup_clojure_test_for_target(TestSetupRequest(batch.single_element, is_debug=True), **implicitly())
     jvm_proc = setup.process
     process = await jvm_process(**implicitly({jvm_proc: JvmProcess}))
+    process = _forward_slot_var(process, clojure_test.execution_slot_var)
 
     return TestDebugRequest(
         InteractiveProcess.from_process(

--- a/pants-plugins/pants_backend_clojure/goals/test.py
+++ b/pants-plugins/pants_backend_clojure/goals/test.py
@@ -34,6 +34,7 @@ from pants.option.option_types import ArgsListOption, SkipOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
+
 from pants_backend_clojure.target_types import (
     ClojureSourceField,
     ClojureTestFieldSet,

--- a/pants-plugins/tests/test_test_runner.py
+++ b/pants-plugins/tests/test_test_runner.py
@@ -1663,3 +1663,79 @@ def test_test_with_extra_jvm_options(rule_runner: RuleRunner) -> None:
     )
 
     assert result.exit_code == 0
+
+
+def test_test_execution_slot_var(rule_runner: RuleRunner) -> None:
+    """Test that --clojure-test-runner-execution-slot-var exposes a slot id env var.
+
+    Only checks that the option forwards a slot id to the child JVM. Uniqueness
+    across concurrent processes is guaranteed by Pants core and not exercised here.
+    """
+    rule_runner.write_files(
+        {
+            "3rdparty/jvm/BUILD": CLOJURE_3RDPARTY_BUILD,
+            "3rdparty/jvm/default.lock": CLOJURE_LOCKFILE,
+            "BUILD": dedent(
+                """\
+                clojure_tests(
+                    name='tests',
+                    dependencies=['3rdparty/jvm:org.clojure_clojure'],
+                )
+                """
+            ),
+            "slot_test.clj": dedent(
+                """\
+                (ns slot-test
+                  (:require [clojure.test :refer [deftest is]]))
+
+                (deftest slot-env-var-is-set
+                  (let [slot (System/getenv "PANTS_EXECUTION_SLOT")]
+                    (is (some? slot)
+                        "PANTS_EXECUTION_SLOT should be set when execution_slot_var is configured")
+                    (is (re-matches #"\\d+" (or slot ""))
+                        "PANTS_EXECUTION_SLOT should be a non-negative integer")))
+                """
+            ),
+        }
+    )
+
+    result = run_clojure_test(
+        rule_runner,
+        "tests",
+        "slot_test.clj",
+        extra_args=["--clojure-test-runner-execution-slot-var=PANTS_EXECUTION_SLOT"],
+    )
+
+    assert result.exit_code == 0
+
+
+def test_test_execution_slot_var_unset_by_default(rule_runner: RuleRunner) -> None:
+    """When execution_slot_var is not set, the env var must not be present."""
+    rule_runner.write_files(
+        {
+            "3rdparty/jvm/BUILD": CLOJURE_3RDPARTY_BUILD,
+            "3rdparty/jvm/default.lock": CLOJURE_LOCKFILE,
+            "BUILD": dedent(
+                """\
+                clojure_tests(
+                    name='tests',
+                    dependencies=['3rdparty/jvm:org.clojure_clojure'],
+                )
+                """
+            ),
+            "no_slot_test.clj": dedent(
+                """\
+                (ns no-slot-test
+                  (:require [clojure.test :refer [deftest is]]))
+
+                (deftest slot-env-var-is-not-set
+                  (is (nil? (System/getenv "PANTS_EXECUTION_SLOT"))
+                      "PANTS_EXECUTION_SLOT should not leak in when not configured"))
+                """
+            ),
+        }
+    )
+
+    result = run_clojure_test(rule_runner, "tests", "no_slot_test.clj")
+
+    assert result.exit_code == 0


### PR DESCRIPTION
I've found this to be very helpful when working with parallel agents.

## Summary

Add a `[clojure-test-runner].execution_slot_var` option mirroring `[pytest].execution_slot_var`. When set, each concurrently running test JVM gets a unique integer slot id in `[0, parallelism)` exposed to the child via the named env var, so tests can carve out non-overlapping resource windows (TCP port ranges, temp dirs, database names) under `process_execution_local_parallelism > 1` without colliding.

Example usage:

```toml
# pants.toml
[clojure-test-runner]
execution_slot_var = "PANTS_EXECUTION_SLOT"
```

```clojure
(let [slot       (Long/parseLong (System/getenv "PANTS_EXECUTION_SLOT"))
      port-start (+ 30000 (* slot 200))]
  ;; bind test fixtures to a per-worker port window
  ...)
```

## Implementation note

`JvmProcess` does not currently forward `execution_slot_variable` to the underlying `Process` (the pex backend does this directly in `pex.py`). Until that's fixed upstream, the test rule does the forwarding itself with `dataclasses.replace(process, execution_slot_variable=slot_var)` after `jvm_process(...)` resolves. A `TODO` in `_forward_slot_var` marks the cleanup. Happy to follow up with the upstream patch to `JvmProcess` separately so this workaround can come out.

## Test plan

- [x] `pants-plugins/tests/test_test_runner.py::test_test_execution_slot_var` — option is forwarded; `(System/getenv "PANTS_EXECUTION_SLOT")` resolves to a non-negative integer in the child JVM
- [x] `pants-plugins/tests/test_test_runner.py::test_test_execution_slot_var_unset_by_default` — when the option is unset, the env var is not present in the child JVM (no accidental leak)

Uniqueness of slot ids across concurrent processes is guaranteed by Pants core and intentionally not re-exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)