### PR TITLE
Add EnvironmentField to Clojure targets

### DIFF
--- a/pants-plugins/pants_backend_clojure/target_types.py
+++ b/pants-plugins/pants_backend_clojure/target_types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.test import (
     TestExtraEnvVarsField,
     TestFieldSet,
@@ -94,6 +95,7 @@ class ClojureSourceTarget(Target):
     alias = "clojure_source"
     core_fields = (
         *COMMON_TARGET_FIELDS,
+        EnvironmentField,
         JvmDependenciesField,
         ClojureSourceField,
         JvmResolveField,
@@ -128,6 +130,7 @@ class ClojureSourcesGeneratorTarget(TargetFilesGenerator):
     generated_target_cls = ClojureSourceTarget
     copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
+        EnvironmentField,
         JvmDependenciesField,
         JvmResolveField,
         JvmJdkField,
@@ -158,6 +161,7 @@ class ClojureTestTarget(Target):
     alias = "clojure_test"
     core_fields = (
         *COMMON_TARGET_FIELDS,
+        EnvironmentField,
         ClojureTestSourceField,
         ClojureTestTimeoutField,
         ClojureTestExtraEnvVarsField,
@@ -188,6 +192,13 @@ class ClojureTestFieldSet(TestFieldSet):
     jdk_version: JvmJdkField
     dependencies: JvmDependenciesField
     extra_env_vars: ClojureTestExtraEnvVarsField
+    # Pants's `_compute_env_field` (pants.core.environments.rules)
+    # iterates the FieldSet's *attributes* looking for an
+    # EnvironmentField — adding it to the Target's core_fields only
+    # isn't enough; the FieldSet must surface it too, or the
+    # environment defaults to `__local__` even when the target sets
+    # `environment="buildbuddy_arm64"`.
+    environment: EnvironmentField
 
 
 @dataclass(frozen=True)
@@ -206,6 +217,7 @@ class ClojureTestsGeneratorTarget(TargetFilesGenerator):
     generated_target_cls = ClojureTestTarget
     copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
+        EnvironmentField,
         ClojureTestTimeoutField,
         ClojureTestExtraEnvVarsField,
         JvmDependenciesField,
@@ -274,6 +286,7 @@ class ClojureDeployJarTarget(Target):
     alias = "clojure_deploy_jar"
     core_fields = (
         *COMMON_TARGET_FIELDS,
+        EnvironmentField,
         JvmDependenciesField,
         ClojureMainNamespaceField,
         ClojureProvidedDependenciesField,


### PR DESCRIPTION
## Summary

- Adds `EnvironmentField` to `clojure_source`, `clojure_sources`, `clojure_test`, `clojure_tests`, and `clojure_deploy_jar` targets (in `core_fields`/`moved_fields`).
- Surfaces `environment: EnvironmentField` on `ClojureTestFieldSet` — Pants's `_compute_env_field` (in `pants.core.environments.rules`) iterates the FieldSet's attributes looking for an `EnvironmentField`, so adding it to the target alone is not sufficient; without this the test rule silently falls back to `__local__`.

## Motivation

Needed to enable remote-API execution for Clojure tests. With `environment="..."` configured on a target, the rule now actually honors it instead of defaulting to local.

## Test plan

- [ ] `clojure_test` with `environment="<remote env>"` runs against the configured remote environment (verify via Pants logs / remote execution dashboard)
- [ ] `clojure_test` with no `environment=` still runs locally (no regression)
- [ ] Existing test suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)