### PR TITLE
lint: ship the full .clj-kondo/ config tree (imported configs) to the sandbox

### DIFF
--- a/pants-plugins/pants_backend_clojure/goals/lint.py
+++ b/pants-plugins/pants_backend_clojure/goals/lint.py
@@ -134,15 +134,31 @@ async def clj_kondo_lint(
         ),
     )
 
-    # Step 2b: Capture .clj-kondo/hooks/ directory for custom hook files.
-    # ConfigFilesRequest only captures individual files, not directories,
-    # so we need a separate PathGlobs to include hook files in the sandbox.
-    hooks_digest = await path_globs_to_digest(
-        PathGlobs(
-            [".clj-kondo/hooks/**"],
-            glob_match_error_behavior=GlobMatchErrorBehavior.ignore,
-        ),
-    )
+    # Step 2b: Capture the rest of the .clj-kondo/ config tree.
+    #
+    # ConfigFilesRequest (Step 2) only captures the root .clj-kondo/config.edn.
+    # clj-kondo also reads, relative to .clj-kondo/:
+    #   - custom hook code under hooks/, and
+    #   - imported library configs under <group-id>/<artifact-id>/ (the standard
+    #     `clj-kondo --copy-configs --dependencies` layout), each of which can
+    #     carry its own config.edn plus hook namespaces.
+    # ConfigFilesRequest captures individual files, not directories, so capture
+    # the whole tree here so imported configs and hooks resolve in the sandbox
+    # exactly as they do for an editor or a bare `clj-kondo` invocation. The
+    # runtime cache (.clj-kondo/.cache) is excluded: it is large, changes every
+    # run (which would bust this action's cache), and is supplied separately as
+    # an append-only cache below.
+    #
+    # NOTE: like Step 2, this only sees anything if the workspace un-ignores the
+    # dotdir, e.g. `[GLOBAL].pants_ignore.add = ["!/.clj-kondo/"]`.
+    clj_kondo_tree_digest = EMPTY_DIGEST
+    if clj_kondo.config_discovery:
+        clj_kondo_tree_digest = await path_globs_to_digest(
+            PathGlobs(
+                [".clj-kondo/**", "!.clj-kondo/.cache/**"],
+                glob_match_error_behavior=GlobMatchErrorBehavior.ignore,
+            ),
+        )
 
     # Step 3: Get source files
     source_files = await determine_source_files(
@@ -163,7 +179,7 @@ async def clj_kondo_lint(
                 source_files.snapshot.digest,
                 downloaded_clj_kondo.digest,
                 config_files.snapshot.digest,
-                hooks_digest,
+                clj_kondo_tree_digest,
                 *classpath_digests,
             ]
         ),

--- a/pants-plugins/pants_backend_clojure/namespace_analysis.py
+++ b/pants-plugins/pants_backend_clojure/namespace_analysis.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import dataclass
 
 from pants.core.util_rules.config_files import ConfigFilesRequest, find_config_file
@@ -101,11 +102,20 @@ async def analyze_clojure_namespaces(
         ),
     )
 
-    # Run clj-kondo analysis in batch mode on all files
+    # Run clj-kondo analysis in batch mode on all files.
+    #
+    # Reference the downloaded binary by its sandbox-relative path ("./clj-kondo")
+    # rather than the bare name ("clj-kondo"). The bare name forces a $PATH lookup,
+    # which finds nothing under local execution (the hermetic sandbox has no PATH)
+    # and makes clj-kondo fail to start — producing empty stdout, an empty
+    # namespace map, and (for deploy-jar packaging) a spurious "could not find
+    # source file for main namespace" error. The "./" form execs the binary that
+    # download_external_tool placed at the sandbox root, and works under both
+    # local and remote execution.
     result = await execute_process(
         Process(
             argv=[
-                downloaded.exe,
+                os.path.join(".", downloaded.exe),
                 "--lint",
                 *request.snapshot.files,
                 "--config",


### PR DESCRIPTION
## Problem

The clj-kondo lint action only captures `.clj-kondo/config.edn` and `.clj-kondo/hooks/**`. It does **not** capture imported library configs under `.clj-kondo/<group-id>/<artifact-id>/` — the standard layout produced by `clj-kondo --copy-configs --dependencies`, where each imported config can carry its own `config.edn` plus hook namespaces.

As a result, any project that relies on imported configs (for us, [Rama](https://redplanetlabs.com/)'s `com.rpl/rama` clj-kondo export, which ships analysis hooks for its dataflow DSL) sees those hooks **silently not run** inside the Pants sandbox. clj-kondo then lints the DSL as ordinary Clojure and emits a flood of false positives that do not occur for an editor or a bare `clj-kondo` invocation against the same tree. In our monorepo this was the difference between 1200+ phantom errors and zero.

## Change

Capture the entire `.clj-kondo/` tree (gated on `config_discovery`, same as the existing config lookup), excluding the runtime cache `.clj-kondo/.cache/**` — it's large, changes every run (which would bust the action's cache), and is already supplied separately as an append-only cache. This makes imported configs and hooks resolve in the sandbox exactly as they do locally.

Net effect: the previous narrow `.clj-kondo/hooks/**` glob is subsumed by `.clj-kondo/**` (minus the cache), so existing hook-only setups are unaffected, and the imported-configs convention now works.

As before, this only sees anything when the workspace un-ignores the dotdir (`[GLOBAL].pants_ignore.add = ["!/.clj-kondo/"]`); the existing subsystem help already documents that.

Happy to add a test fixture (an imported `<group>/<artifact>/config.edn` + a source file that only lints clean when that config is present) if you'd like one with this.
