### PR TITLE
Report the actually-bound nREPL port instead of the configured one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The nREPL startup message now reports the port the server actually bound
+  instead of echoing the configured `[nrepl].port` value. With `port = 0`
+  (OS-assigned ephemeral port) the message previously printed
+  "nREPL server started on port 0". The `[nrepl].port` help text now also
+  documents the `0` auto-select behavior.
+
 ## [0.2.3] - 2026-05-24
 
 ### Added

--- a/pants-plugins/pants_backend_clojure/goals/repl.py
+++ b/pants-plugins/pants_backend_clojure/goals/repl.py
@@ -85,6 +85,22 @@ def _prepare_repl_for_workspace(argv: Iterable[str], env: dict[str, str], jdk: J
     return prefixed_argv, prefixed_env
 
 
+def _build_nrepl_start_code(host: str, port: int) -> str:
+    """Build the Clojure form that starts the nREPL server and blocks forever.
+
+    The startup message reads the bound port from the server's :port slot rather
+    than echoing the configured value: when the configured port is 0 the OS picks
+    an ephemeral port, and only the server map knows which one it got.
+    """
+    return (
+        f"(require (quote nrepl.server)) "
+        f'(let [server (nrepl.server/start-server :bind "{host}" :port {port})] '
+        f"(println server) "
+        f'(println (str "nREPL server started on port " (:port server))) '
+        f"@(promise))"  # Block forever
+    )
+
+
 class ClojureReplSubsystem(Subsystem):
     """Configuration for Clojure REPL behavior."""
 
@@ -122,7 +138,7 @@ class NReplSubsystem(Subsystem):
 
     port = IntOption(
         default=7888,
-        help="Port for nREPL server to bind to.",
+        help=("Port for nREPL server to bind to. Use 0 to let the OS pick a free ephemeral port; the chosen port is printed on startup."),
     )
 
     host = StrOption(
@@ -419,15 +435,7 @@ async def create_nrepl_request(
         *nrepl_classpath.classpath_entries(),
     ]
 
-    # Command to start nREPL server and keep it running
-    # The server is stored in an atom and we use deref (@) to block indefinitely
-    nrepl_start_code = (
-        f"(require (quote nrepl.server)) "
-        f'(let [server (nrepl.server/start-server :bind "{host}" :port {port})] '
-        f"(println server) "
-        f'(println "nREPL server started on port {port}") '
-        f"@(promise))"  # Block forever
-    )
+    nrepl_start_code = _build_nrepl_start_code(host, port)
 
     argv = [
         *setup.jdk.args(bash, classpath_entries),

--- a/pants-plugins/tests/test_repl.py
+++ b/pants-plugins/tests/test_repl.py
@@ -16,7 +16,7 @@ from pants.jvm.target_types import JvmArtifactTarget
 from pants.jvm.util_rules import rules as jdk_util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
 from pants_backend_clojure import compile_clj
-from pants_backend_clojure.goals.repl import ClojureNRepl, ClojureRebelRepl, ClojureRepl
+from pants_backend_clojure.goals.repl import ClojureNRepl, ClojureRebelRepl, ClojureRepl, _build_nrepl_start_code
 from pants_backend_clojure.goals.repl import rules as repl_rules
 from pants_backend_clojure.namespace_analysis import rules as namespace_analysis_rules
 from pants_backend_clojure.target_types import (
@@ -706,6 +706,28 @@ def test_repl_classpath_includes_source_roots(rule_runner: RuleRunner) -> None:
             break
     else:
         pytest.fail("-cp argument not found in argv")
+
+
+def test_nrepl_start_code_binds_configured_host_and_port() -> None:
+    """Test that the nREPL startup form passes the configured host and port through."""
+    code = _build_nrepl_start_code("127.0.0.1", 7888)
+
+    assert '(nrepl.server/start-server :bind "127.0.0.1" :port 7888)' in code
+
+
+def test_nrepl_start_code_reports_actual_bound_port() -> None:
+    """Test that the startup message reports the port the server actually bound.
+
+    With port 0 the OS auto-selects an ephemeral port, so the message must read
+    the bound port from the server's :port slot at runtime instead of echoing
+    the configured value (which would print "started on port 0").
+    """
+    code = _build_nrepl_start_code("127.0.0.1", 0)
+
+    # The message must be built from the server map's :port slot...
+    assert '(str "nREPL server started on port " (:port server))' in code
+    # ...not interpolated from the configured port value.
+    assert "started on port 0" not in code
 
 
 # NOTE: nREPL tests are skipped because they require fetching the nREPL artifact


### PR DESCRIPTION
## Problem

When `[nrepl].port` is set to `0` (asking the OS to auto-select a free ephemeral port), the nREPL server binds an OS-assigned port — but the startup message interpolates the *configured* value into the printed string, so the REPL announces:

```
nREPL server started on port 0
```

That leaves the user with no usable way to find the real port from the startup output.

## Fix

Build the startup message from the server map's `:port` slot at runtime instead of interpolating the configured value. `nrepl.server/start-server`'s docstring explicitly designates this slot for exactly this case:

> The port that the server is open on is available in the :port slot of the server map (useful if the :port option is 0 or was left unspecified).

(Internally it's `(.getLocalPort server-socket)`, so it's correct for explicit ports too — the message is unchanged for non-zero configurations.)

Also:
- Documents the `0` auto-select behavior in the `[nrepl].port` option help.
- Extracts the start-code construction into a pure `_build_nrepl_start_code(host, port)` helper and adds two unit tests for it. The existing nREPL rule-level tests are skipped because they need the nREPL artifact from Maven; the helper keeps the message logic testable without network access.
- Adds a CHANGELOG entry under `[Unreleased]`.

## Testing

`pants-plugins/tests/test_repl.py`: 16 passed (14 existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)